### PR TITLE
Fix extra Japanese font-family settings

### DIFF
--- a/misc/ReadiumCSS/ReadiumCSS-ebpaj_fonts_patch.css
+++ b/misc/ReadiumCSS/ReadiumCSS-ebpaj_fonts_patch.css
@@ -29,9 +29,11 @@
        local("ヒラギノ明朝 Pro W3"),
        local("游明朝"),
        local("YuMincho"),
+       local("Yu Mincho")
        local("ＭＳ 明朝"),
        local("MS Mincho"),
-       local("Hiragino Mincho ProN");
+       local("Hiragino Mincho ProN"),
+       local("BIZ UDPMincho");
 }
 
 @font-face {
@@ -44,9 +46,11 @@
        local("ヒラギノ角ゴシック W3"),
        local("游ゴシック"),
        local("YuGothic"),
+       local("Yu Gothic"),
        local("ＭＳ ゴシック"),
        local("MS Gothic"),
-       local("Hiragino Sans");
+       local("Hiragino Sans"),
+       local("BIZ UDPGothic");
 }
 
 /* 縦組み用 (vertical writing) */
@@ -59,9 +63,11 @@
        local("ヒラギノ明朝 Pro W3"),
        local("游明朝"),
        local("YuMincho"),
+       local("Yu Mincho"),
        local("ＭＳ Ｐ明朝"),
        local("MS PMincho"),
-       local("Hiragino Mincho ProN");
+       local("Hiragino Mincho ProN"),
+       local("BIZ UDMincho");
 }
 
 @font-face {
@@ -74,7 +80,9 @@
        local("ヒラギノ角ゴシック W3"),
        local("游ゴシック"),
        local("YuGothic"),
+       local("Yu Gothic"),
        local("ＭＳ Ｐゴシック"),
        local("MS PGothic"),
-       local("Hiragino Sans");
+       local("Hiragino Sans"),
+       local("BIZ UDGothic");
 }

--- a/misc/ReadiumCSS/cjk-horizontal/ReadiumCSS-before.css
+++ b/misc/ReadiumCSS/cjk-horizontal/ReadiumCSS-before.css
@@ -175,10 +175,10 @@ math {
   --RS__lineHeightCompensation: 1.167;
 
   /* Extra variables for Japanese font-stacks as we may want to reuse them for user settings + default */
-  --RS__serif-ja: "ＭＳ Ｐ明朝", "MS PMincho", "Hiragino Mincho Pro", "ヒラギノ明朝 Pro W3", "游明朝", "YuMincho", "ＭＳ 明朝", "MS Mincho", "Hiragino Mincho ProN", serif;
-  --RS__sans-serif-ja: "ＭＳ Ｐゴシック", "MS PGothic", "Hiragino Kaku Gothic Pro W3", "ヒラギノ角ゴ Pro W3", "Hiragino Sans GB", "ヒラギノ角ゴシック W3", "游ゴシック", "YuGothic", "ＭＳ ゴシック", "MS Gothic", "Hiragino Sans", sans-serif;
-  --RS__serif-ja-v: "ＭＳ 明朝", "MS Mincho", "Hiragino Mincho Pro", "ヒラギノ明朝 Pro W3", "游明朝", "YuMincho", "ＭＳ Ｐ明朝", "MS PMincho", "Hiragino Mincho ProN", serif;
-  --RS__sans-serif-ja-v: "ＭＳ ゴシック", "MS Gothic", "Hiragino Kaku Gothic Pro W3", "ヒラギノ角ゴ Pro W3", "Hiragino Sans GB", "ヒラギノ角ゴシック W3", "游ゴシック", "YuGothic", "ＭＳ Ｐゴシック", "MS PGothic", "Hiragino Sans", sans-serif;
+  --RS__serif-ja: "Hiragino Mincho ProN", "BIZ UDPMincho", "Yu Mincho", "MS PMincho", serif;
+  --RS__sans-serif-ja: "Hiragino Kaku Gothic ProN", "Hiragino Sans W3", "Hiragino Sans", "BIZ UDPGothic", "Yu Gothic", "MS PGothic", sans-serif;
+  --RS__serif-ja-v: "Hiragino Mincho ProN", "BIZ UDMincho", "Yu Mincho", "MS Mincho", serif;
+  --RS__sans-serif-ja-v: "Hiragino Kaku Gothic ProN", "Hiragino Sans W3", "Hiragino Sans", "BIZ UDGothic", "Yu Gothic", "MS Gothic", sans-serif;  
 }
 
 :lang(km) {

--- a/misc/ReadiumCSS/cjk-vertical/ReadiumCSS-before.css
+++ b/misc/ReadiumCSS/cjk-vertical/ReadiumCSS-before.css
@@ -175,10 +175,10 @@ math {
   --RS__lineHeightCompensation: 1.167;
 
   /* Extra variables for Japanese font-stacks as we may want to reuse them for user settings + default */
-  --RS__serif-ja: "ＭＳ Ｐ明朝", "MS PMincho", "Hiragino Mincho Pro", "ヒラギノ明朝 Pro W3", "游明朝", "YuMincho", "ＭＳ 明朝", "MS Mincho", "Hiragino Mincho ProN", serif;
-  --RS__sans-serif-ja: "ＭＳ Ｐゴシック", "MS PGothic", "Hiragino Kaku Gothic Pro W3", "ヒラギノ角ゴ Pro W3", "Hiragino Sans GB", "ヒラギノ角ゴシック W3", "游ゴシック", "YuGothic", "ＭＳ ゴシック", "MS Gothic", "Hiragino Sans", sans-serif;
-  --RS__serif-ja-v: "ＭＳ 明朝", "MS Mincho", "Hiragino Mincho Pro", "ヒラギノ明朝 Pro W3", "游明朝", "YuMincho", "ＭＳ Ｐ明朝", "MS PMincho", "Hiragino Mincho ProN", serif;
-  --RS__sans-serif-ja-v: "ＭＳ ゴシック", "MS Gothic", "Hiragino Kaku Gothic Pro W3", "ヒラギノ角ゴ Pro W3", "Hiragino Sans GB", "ヒラギノ角ゴシック W3", "游ゴシック", "YuGothic", "ＭＳ Ｐゴシック", "MS PGothic", "Hiragino Sans", sans-serif;
+  --RS__serif-ja: "Hiragino Mincho ProN", "BIZ UDPMincho", "Yu Mincho", "MS PMincho", serif;
+  --RS__sans-serif-ja: "Hiragino Kaku Gothic ProN", "Hiragino Sans W3", "Hiragino Sans", "BIZ UDPGothic", "Yu Gothic", "MS PGothic", sans-serif;
+  --RS__serif-ja-v: "Hiragino Mincho ProN", "BIZ UDMincho", "Yu Mincho", "MS Mincho", serif;
+  --RS__sans-serif-ja-v: "Hiragino Kaku Gothic ProN", "Hiragino Sans W3", "Hiragino Sans", "BIZ UDGothic", "Yu Gothic", "MS Gothic", sans-serif;  
 }
 
 :lang(km) {


### PR DESCRIPTION
Additional specification and adjustment of Japanese font environment in Windows environment.

- MS Gothic/MS Mincho is specified first, so it is displayed with top priority. However, I don't think it's very good because the jaggies are noticeable on the display.
- Therefore, I would like to prioritize the BIZ UD fonts added in recent years, and replace them in the order of Yu fonts and then MS fonts.
    - With the standard font settings, the BIZ font also clogs up the margins of punctuation marks, but I think it's better than the Yu/MS font.
- For macOS, I think there will be no problem for the time being by having the Hiragino font specified first.
- In current browsers, it is no longer necessary to specify both English and Japanese when specifying the Japanese font-family. Therefore, I chose to use only English.
    - However, Yu Fonts has different English names ("Yu Gothic", "YuGothic") in Windows and macOS environments... Therefore, it is necessary to specify both.