### PR TITLE
Do not mark Traditional Chinese (zh-Hant and zh-TW) as a RTL language

### DIFF
--- a/src/electron/common/readium-css-inject.ts
+++ b/src/electron/common/readium-css-inject.ts
@@ -114,10 +114,7 @@ export function isDocRTL(documant: Document): boolean {
         if (langAttr &&
             (langAttr === "ar" || langAttr.startsWith("ar-") ||
             langAttr === "he" || langAttr.startsWith("he-") ||
-            langAttr === "fa" || langAttr.startsWith("fa-")) ||
-            langAttr === "zh-Hant" ||
-            langAttr === "zh-TW"
-            ) {
+            langAttr === "fa" || langAttr.startsWith("fa-"))) {
             // foundLang = true;
             rtl = true;
         }


### PR DESCRIPTION
This is a companion PR to https://github.com/edrlab/thorium-reader/pull/3027

I have only changed the RTL language logic for dependencies of [Thorium Reader](https://github.com/edrlab/thorium-reader) such that I get correct results in that program.
I may have missed other Readium repositories that may also feature such a language determination logic.

See https://github.com/edrlab/thorium-reader/pull/3027 for more details/rationale.